### PR TITLE
Enhance the configuration of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,36 @@
+# See https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose
+# `docker compose` should now be used instead of `docker-compose`
+
 #######
 # DEV #
 #######
 
 up:
 	docker-compose up
+up-new:
+	docker compose up
 
 upd:
 	docker-compose up -d
+upd-new:
+	docker compose up -d
 
 buildup:
 	docker-compose up --build
+buildup-new:
+	docker compose up --build
 
 buildupd:
 	docker-compose up --build -d
+buildupd-new:
+	docker compose up --build -d
 
 migr:
 	docker-compose exec web python manage.py makemigrations
 	docker-compose exec web python manage.py migrate --noinput
+migr-new:
+	docker compose exec web python manage.py makemigrations
+	docker compose exec web python manage.py migrate --noinput
 
 migr-show:
 	docker-compose exec web python manage.py showmigrations
@@ -29,9 +43,13 @@ static:
 
 admin:
 	docker-compose exec web python manage.py createsuperuser
+admin-new:
+	docker compose exec web python manage.py createsuperuser
 
 down:
 	docker-compose down
+down-new:
+	docker compose down
 	
 downv:
 	docker-compose down -v

--- a/platform_code/entrypoint.sh
+++ b/platform_code/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Check end of lines config: require CRLF on Unix and LF on Windows
+
 if [ "$DATABASE" = "postgres" ]
 then
     echo "Waiting for postgres..."


### PR DESCRIPTION
- [x] Add comment in `entrypoint.sh` about the specifics of the end of lines characters depending on the underlying system (e.g. CRLF for Unix, LF for Windows)
- [x] Add comment in `Makefile` and duplicate commands to reflect deprecation of `docker-compose` now replaced by `docker compose`